### PR TITLE
Resolves SyntaxWarning regarding "is" vs "==" operator.

### DIFF
--- a/dgpulldown2_python/dgpulldown2.py
+++ b/dgpulldown2_python/dgpulldown2.py
@@ -436,7 +436,7 @@ class dgpulldown():
                         # rewrite trf
                         #trf = tff ? tff_flags[D] :  bff_flags[D]
                         print('D value: {}'.format(D))
-                        if self.tff is 1:
+                        if self.tff == 1:
                             trf = self.tff_flags[D]
                         else:
                             trf = self.bff_flags[D]


### PR DESCRIPTION
Resolves SyntaxWarning on line 439...

```
dgpulldown2.py:439: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
  if self.tff is 1:
```

```
$ python3 ./dgpulldown2.py -h

./dgpulldown2.py:439: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
  if self.tff is 1:

usage: dgpulldown2.py [-h] -i INPUT [-o OUTPUT] [-srcfps SRCFPS] [-destfps DESTFPS] [-df DF] [-nodf NODF] [-bff BFF]

dgpulldown(python)

options:
  -h, --help        show this help message and exit
  -i INPUT          File name for input file.
  -o OUTPUT         File name for output file, if omitted the name will be "*.pulldown.m2v".
  -srcfps SRCFPS    Rate is any float fps value, e.g., "23.976" (default) or a fraction, e.g., "30000/1001"
  -destfps DESTFPS  Rate is any valid mpeg2 float fps value, e.g., "29.97" (default). Valid rates: 23.976, 24, 25,
                    29.97, 30, 50, 59.94, 60"
  -df DF            Force dropframes.
  -nodf NODF        Force no dropframes.
  -bff BFF          Generate a BFF (Bottom Field First) output stream. If absent, a TFF (Top Field First) stream is
                    generated. NTSC is BFF, PAL is TFF
```